### PR TITLE
Fix sername miner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Roosterize output
+output/

--- a/roosterize/data/DataMiner.py
+++ b/roosterize/data/DataMiner.py
@@ -691,7 +691,7 @@ class DataMiner:
         lemma_qnames_file = BashUtils.get_temp_file()
         IOUtils.dump(lemma_qnames_file, lemma_qnames, IOUtils.Format.txt)
 
-        lemma_qnames_backend_sexps_str: str = BashUtils.run(f"sername --require-lib={qprefix_this_doc} {lemma_qnames_file}", expected_return_code=0).stdout
+        lemma_qnames_backend_sexps_str: str = BashUtils.run(f"sername {serapi_options} --require-lib={qprefix_this_doc} {lemma_qnames_file}", expected_return_code=0).stdout
         IOUtils.rm(lemma_qnames_file)
         for qname_backend_sexp_str in lemma_qnames_backend_sexps_str.splitlines():
             qname, backend_sexp_str = qname_backend_sexp_str.split(":", 1)


### PR DESCRIPTION
@pengyunie does this make sense to you? Without it, I get `sername` related exceptions when the Coq project directory is not globally available to Coq (i.e., Coq will not be able to locate the `.vo` files).